### PR TITLE
Resolves: StyledLabel inline image dimensions on android do not change when they are specified

### DIFF
--- a/android/src/ti/styledlabel/parsing/HtmlToSpannedConverter.java
+++ b/android/src/ti/styledlabel/parsing/HtmlToSpannedConverter.java
@@ -498,16 +498,42 @@ public class HtmlToSpannedConverter implements ContentHandler {
 
 	private void startImg(Attributes attributes) {
 		String src = attributes.getValue("", "src");
+		String width= attributes.getValue("", "width");
+		String height= attributes.getValue("", "height");
 		Drawable d = null;
 
 		if (mImageGetter != null) {
 			d = mImageGetter.getDrawable(src);
 		}
 
+		
 		if (d == null) {
 			mSB.setSpan(new BackgroundColorSpan(0), mSB.length(), mSB.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 			return;
 		}
+		else{
+			int weidthInAttributes=d.getIntrinsicWidth();
+			int heightInAttributes=d.getIntrinsicHeight();
+			if(width!=null){
+				try{
+					weidthInAttributes=Integer.parseInt(width);
+				}
+				catch(NumberFormatException nfe){
+					Util.e("NumberFormatException on width attribute");
+				}
+			}
+			if(height!=null){
+				try{
+					heightInAttributes=Integer.parseInt(height);
+				}
+				catch(NumberFormatException nfe){
+					Util.e("NumberFormatException on height attribute");
+				}
+			}
+			d.setBounds(0,0,weidthInAttributes,heightInAttributes);
+		}
+		
+		
 
 		int len = mSB.length();
 		mSB.append("\uFFFC");

--- a/android/src/ti/styledlabel/parsing/HtmlToSpannedConverter.java
+++ b/android/src/ti/styledlabel/parsing/HtmlToSpannedConverter.java
@@ -498,48 +498,45 @@ public class HtmlToSpannedConverter implements ContentHandler {
 
 	private void startImg(Attributes attributes) {
 		String src = attributes.getValue("", "src");
-		String width= attributes.getValue("", "width");
-		String height= attributes.getValue("", "height");
+		String width = attributes.getValue("", "width");
+		String height = attributes.getValue("", "height");
 		Drawable d = null;
 
 		if (mImageGetter != null) {
 			d = mImageGetter.getDrawable(src);
 		}
 
-		
 		if (d == null) {
-			mSB.setSpan(new BackgroundColorSpan(0), mSB.length(), mSB.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+			mSB.setSpan(new BackgroundColorSpan(0), mSB.length(), mSB.length(),
+					Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 			return;
-		}
-		else{
-			int weidthInAttributes=d.getIntrinsicWidth();
-			int heightInAttributes=d.getIntrinsicHeight();
-			if(width!=null){
-				try{
-					weidthInAttributes=Integer.parseInt(width);
-				}
-				catch(NumberFormatException nfe){
+		} else {
+			int widthInAttributes = d.getIntrinsicWidth();
+			int heightInAttributes = d.getIntrinsicHeight();
+			if (width != null) {
+				try {
+					widthInAttributes = Integer.parseInt(width);
+				} catch (NumberFormatException nfe) {
 					Util.e("NumberFormatException on width attribute");
 				}
 			}
-			if(height!=null){
-				try{
-					heightInAttributes=Integer.parseInt(height);
-				}
-				catch(NumberFormatException nfe){
+			if (height != null) {
+				try {
+					heightInAttributes = Integer.parseInt(height);
+				} catch (NumberFormatException nfe) {
 					Util.e("NumberFormatException on height attribute");
 				}
 			}
-			d.setBounds(0,0,weidthInAttributes,heightInAttributes);
+			d.setBounds(0, 0, widthInAttributes, heightInAttributes);
 		}
-		
-		
 
 		int len = mSB.length();
 		mSB.append("\uFFFC");
 
-		mSB.setSpan(new ImageSpan(d, src), len, mSB.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+		mSB.setSpan(new ImageSpan(d, src), len, mSB.length(),
+				Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 	}
+
 
 	private void endFont(TagMarker tm) {
 		int end = mSB.length();


### PR DESCRIPTION
The image dimension properties such as width and height previously did not affect the image. This issue is resolved here.

[MOD-2038] Handles width and height attribute in "startImg" method in HtmlToSpannedConverter.java file.

Link of the jira ticket : [MOD-2038](https://jira.appcelerator.org/browse/MOD-2038)
