### PR TITLE
[MOD-1904] Changes createView method in LabelProxy.java to make the label unclickable (Resolves :Click event fires twice)

### DIFF
--- a/android/src/ti/styledlabel/LabelProxy.java
+++ b/android/src/ti/styledlabel/LabelProxy.java
@@ -23,7 +23,9 @@ public class LabelProxy extends TiViewProxy {
 
 	@Override
 	public TiUIView createView(Activity activity) {
-		return new Label(this);
+		Label label=new Label(this);
+		label.getNativeView().setClickable(false);
+		return label;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes following ticket:
[https://jira.appcelerator.org/browse/MOD-1904](MOD-1904)